### PR TITLE
Version 1.0.5 - Python 3.14 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.11", "3.12","3.13"]
+        python: ["3.11", "3.12","3.13","3.14"]
     env:
       CPG_HOST: ${{ vars.CPG_HOST }}
       CPG_USER: ${{ vars.CPG_USER }}
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install tox
-        run: pip install tox==4.25.0
+        run: pip install tox==4.34.1
       - name: Run Unit tests
         run: cd pycpg; tox -e py  # Run tox using the version of Python in `PATH`
       - name: Submit coverage report

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,8 +18,8 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v1
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install tox
-      run: pip install tox==4.25.0
+      run: pip install tox==4.34.1
     - name: Build docs
       run: tox -e docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.13"
 
 
 # Build documentation in the docs/ directory with Sphinx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The intended audience of this file is for pycpg consumers -- as such, changes that don't affect
 how a consumer would use the library (e.g. adding unit tests, updating documentation, etc) are not captured here.
 
+## 1.0.5 - 2026-02-11
+
+## Changed
+
+- Added support for python 3.14
+- Updated dependencies
+
 ## 1.0.4 - 2025-06-16
 
 ### Changed

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 CrashPlan Software
+Copyright (c) 2026 CrashPlan Software
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/methoddocs/archive.md
+++ b/docs/methoddocs/archive.md
@@ -1,12 +1,6 @@
 # Archive
 
 ```{eval-rst}
-.. important::
-    You must be using pycpg to version 1.25.1 or higher to use the `archive.stream_from_backup()` or `archive.stream_to_device()` methods.
-
-```
-
-```{eval-rst}
 .. autoclass:: pycpg.clients.archive.ArchiveClient
     :members:
     :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 license = "MIT"
 license-files = ["LICENSE.md"]
 name = "pycpg"
-version = "1.0.4"
+version = "1.0.5"
 description = "The Official CrashPlan Python API Client"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.11"
@@ -16,13 +16,14 @@ dependencies = [
     "requests >=2.32.4",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Natural Language :: English",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.11"
 keywords = ["backup","crashplan"]
 dependencies = [
-    "urllib3 >=2.4.0",
-    "requests >=2.32.4",
+    "urllib3 >=2.6.3",
+    "requests >=2.32.5",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -39,17 +39,17 @@ include = ["pycpg*"]
 
 [project.optional-dependencies]
 docs = [
-    "sphinx==8.2.3",
-    "myst-parser==4.0.1",
-    "sphinx_rtd_theme==3.0.2",
-    "docutils == 0.21.2",
+    "sphinx==9.1.0",
+    "myst-parser==5.0.0",
+    "sphinx_rtd_theme==3.1.0",
+    "docutils == 0.22.4",
 ]
 dev = [
-    "flake8 == 7.2.0",
-    "pytest == 8.4.0",
-    "pytest-cov == 6.1.1",
-    "pytest-mock == 3.10.0",
-    "tox == 4.25.0",
+    "flake8 == 7.3.0",
+    "pytest == 9.0.2",
+    "pytest-cov == 7.0.0",
+    "pytest-mock == 3.15.1",
+    "tox == 4.34.1",
 ]
 all = [
     "test_self_dep[docs,DEV]"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = true
 envlist =
-    py{311,312,313}
+    py{311,312,313,314}
     docs
     style
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,9 @@ skip_missing_interpreters = true
 
 [testenv]
 deps =
-    pytest == 8.4.0
-    pytest-mock == 3.10.0
-    pytest-cov == 6.1.1
+    pytest == 9.0.2
+    pytest-mock == 3.15.1
+    pytest-cov == 7.0.0
 
 commands =
     # -v: verbose
@@ -24,10 +24,10 @@ commands =
 
 [testenv:docs]
 deps =
-    sphinx == 8.2.3
-    myst-parser == 4.0.1
-    sphinx_rtd_theme == 3.0.2
-    docutils == 0.21.2
+    sphinx == 9.1.0
+    myst-parser == 5.0.0
+    sphinx_rtd_theme == 3.1.0
+    docutils == 0.22.4
 
 allowlist_externals = bash
 


### PR DESCRIPTION
### Description of Change ###

Mostly this change increases the python version to 3.14 and increases the supporting libraries to match.

### Issues Resolved ###

- [X] Add unit tests to verify this change
- [X] Add an entry to CHANGELOG.md describing this change
- [X] Add docstrings for any new public parameters / methods / classes
